### PR TITLE
Fix sub() in list-out-of-lambda.html

### DIFF
--- a/content/blog/2013/03/list-out-of-lambda.html
+++ b/content/blog/2013/03/list-out-of-lambda.html
@@ -789,7 +789,7 @@ smaller, we *decrease* them both together:
         if (is_zero(b)) {
             return a;
         } else {
-            return add(dec(a), dec(b));
+            return sub(dec(a), dec(b));
         }
     };
 


### PR DESCRIPTION
I think, `sub()` should call itself, not an `add()`, to work as you describe it.

Now it's like this: `sub(5,3) = add(4,2) = … = 6` — not so helpful subtraction function as you can see. :)
